### PR TITLE
minor label update

### DIFF
--- a/src/arrays/find.js
+++ b/src/arrays/find.js
@@ -4,7 +4,7 @@
  *
  * @param {Array} array
  * @param {Function} predicate to be run against each element of the array
- * @param {*} thisArg of this
+ * @param {*} [thisArg=undefined] of this
  * @returns {*} value of element that satisfied function.
  * @example
  * const result = arrays.find([5, 12, 8, 130, 44], (x) => x > 10);

--- a/src/arrays/indexOf.js
+++ b/src/arrays/indexOf.js
@@ -4,7 +4,7 @@
  *
  * @param {Array} array
  * @param {number} searchElement to be looked for in the array
- * @param {number} start index in array to begin searching for search Element
+ * @param {number} [start=0] index in array to begin searching for search Element
  * @returns {number} a integer representing the first index in the array that contains the element
  * @example
  * const result = arrays.indexOf([1,2,3,4,5,4], 4, 4));

--- a/src/arrays/zip.js
+++ b/src/arrays/zip.js
@@ -4,7 +4,7 @@
  *
  * @param {Array} array1 input array
  * @param {Array} array2 input array
- * @param {Function} predicate optional to be applied to corresponding values
+ * @param {Function} [predicate=(a, b)=>[a, b]] to be applied to corresponding values
  * @returns {Array} input array filled value pairs after the function has been applied
  *
  * @example

--- a/src/strings/startsWith.js
+++ b/src/strings/startsWith.js
@@ -3,7 +3,7 @@
  *
  * @param {string} string input string
  * @param {string} substr substring to test
- * @returns {string} does the input start with the substring?
+ * @returns {boolean} does the input start with the substring?
  *
  * @example
  * const result = strings.startsWith('This sentence starts with', 'This');

--- a/src/strings/startsWith.spec.js
+++ b/src/strings/startsWith.spec.js
@@ -21,7 +21,7 @@ test('strings.startsWith(string, substr) - returns falsy when the string does no
   t.end();
 });
 
-test('strings.startsWith(string, substr) - returns falsy when the string does not start with the substr', t => {
+test('strings.startsWith(string, substr) - returns falsy when the string does not start with the substring', t => {
   const expect = false;
   const result = strings.startsWith('abc', 'f');
 


### PR DESCRIPTION
fixed return type of startWith
kept consistancy of substring naming, could be "substr", but went with majority.