### PR TITLE
changed so concat combines elements of arrays without flattening

### DIFF
--- a/src/arrays/concat.js
+++ b/src/arrays/concat.js
@@ -7,21 +7,17 @@
  * @example
  * const result = arrays.concat([1], 2, [3], [[4]]);
  * console.log(result);
- * > [1, 2, 3, 4]
+ * > [1, 2, 3, [4]]
  */
 function concat (...arrays) {
-  return flatten(arrays, []);
-}
-
-function flatten (array, initial = []) {
-  return array.reduce((acc, curr) => {
-    if (Array.isArray(curr)) {
-      acc = flatten(curr, acc);
+  return [...arrays].reduce((res, cur) => {
+    if (typeof cur === 'object') {
+      res.push(...cur);
     } else {
-      acc.push(curr);
+      res.push(cur);
     }
-    return acc;
-  }, initial);
+    return res;
+  });
 }
 
 export { concat };

--- a/src/arrays/concat.spec.js
+++ b/src/arrays/concat.spec.js
@@ -1,12 +1,34 @@
 import test from 'tape';
 import { arrays } from '../../index.js';
 
-test('arrays.concat(...arrays) - should return an array with all inputs flattened and concatenated', t => {
-  const expect = [1, 2, 3, 4];
+test('arrays.concat(...arrays) - should return an array with all inputs concatenated', t => {
+  const expect = ['Hello', 'Greetings', 'Farewell', 'Goodbye'];
+  const result = arrays.concat(['Hello', 'Greetings'], ['Farewell', 'Goodbye']);
+
+  t.equal(Object.prototype.toString.call(result), '[object Array]', 'return type');
+  t.equal(result.length, 4, 'output length');
+  t.deepEqual(result, expect, 'output value');
+
+  t.end();
+});
+
+test('arrays.concat(...arrays) - should return an array with all inputs concatenated', t => {
+  const expect = [1, 2, 3, [4]];
   const result = arrays.concat([1], 2, [3], [[4]]);
 
   t.equal(Object.prototype.toString.call(result), '[object Array]', 'return type');
   t.equal(result.length, 4, 'output length');
+  t.deepEqual(result, expect, 'output value');
+
+  t.end();
+});
+
+test('arrays.concat(...arrays) - should return an array with all inputs concatenated', t => {
+  const expect = ['Tao', 2, 'Apolline', [3], 5];
+  const result = arrays.concat(['Tao'], 2, ['Apolline', [3]], [5]);
+
+  t.equal(Object.prototype.toString.call(result), '[object Array]', 'return type');
+  t.equal(result.length, 5, 'output length');
   t.deepEqual(result, expect, 'output value');
 
   t.end();


### PR DESCRIPTION
Ref: #43 
based implementation off of 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat
Specifically functionality that was missing in section on "Concatenating nested arrays".