### PR TITLE
Fix objects.mapKeys

### DIFF
--- a/src/objects/mapKeys.js
+++ b/src/objects/mapKeys.js
@@ -11,6 +11,7 @@
  * > { neat_1: 1, neat_2: 2, neat_3: 3 }
  */
 function mapKeys (object, func) {
+  if (typeof func !== 'function') { return object; }
   return Object.entries(object).reduce(
     (acc, [key, value]) => ({
       ...acc,

--- a/src/objects/mapKeys.spec.js
+++ b/src/objects/mapKeys.spec.js
@@ -20,3 +20,13 @@ test('objects.mapKeys(object) - returns an object with updated keys using values
 
   t.end();
 });
+
+test('objects.mapKeys(object) - returns the input object if no function is applied', t => {
+  const expect = { a: 1, b: 2, c: 3 };
+  const result = objects.mapKeys({ a: 1, b: 2, c: 3 });
+
+  t.equal(Object.prototype.toString.call(result), '[object Object]', 'return type');
+  t.deepEqual(result, expect, 'output value');
+
+  t.end();
+});


### PR DESCRIPTION
Short-circuit to return the input `object` when no `func` parameter is present

Ref #142 